### PR TITLE
tests: support quicklisp

### DIFF
--- a/tests/lispvirt-run.lisp
+++ b/tests/lispvirt-run.lisp
@@ -19,10 +19,28 @@
 ;;; along with Lispvirt.  If not, see <http://www.gnu.org/licenses/>.
 ;;;-------------------------------------------------------------------------
 
+
+(defun getenv (name &optional default)
+  "Obtains the current value of the POSIX environment variable NAME."
+  (declare (type (or string symbol) name))
+  (let ((name (string name)))
+    (or #+abcl (ext:getenv name)
+        #+ccl (ccl:getenv name)
+        #+clisp (ext:getenv name)
+        #+cmu (unix:unix-getenv name) ; since CMUCL 20b
+        #+ecl (si:getenv name)
+        #+gcl (si:getenv name)
+        #+mkcl (mkcl:getenv name)
+        #+sbcl (sb-ext:posix-getenv name)
+        default)))
+
+(let ((ql-setup (getenv "QUICKLISP_SETUP")))
+  (when (and ql-setup (probe-file ql-setup))
+    (load ql-setup)))
+
 (require 'asdf)
 
 (asdf:load-system :lispvirt-tests)
-
 (in-package :lispvirt-tests)
 
 (run-all-tests)


### PR DESCRIPTION
This is a first step for quicklisp support.
If a QUICKLISP_SETUP environment variable exists, load
the file. This can be pointed to the quicklisp setup.lisp
file, which will take care of loading dependencies when needed.
